### PR TITLE
[59] fallback option per hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ useSWR(() => "_", {
     cache: new LRU<string, CacheItem>(5e3),
     onSuccess: noop,
     onError: noop,
+    fallback: {},
     revalidateOnFocus: true,
     revalidateOnOnline: true,
 });
@@ -133,6 +134,7 @@ The options are merged with context, [read more](#context)
 | `onError`            | A callback that gets the error when it gets updated with a truthy error |                                                                                  `noop` |
 | `revalidateOnFocus`  |          Automatically revalidate when window has gotten focus          |                                                                                  `true` |
 | `revalidateOnOnline` |           Automatically revalidate when connection came back            |                                                                                  `true` |
+| `fallback`           |    A simple object in which you can provide initial values for keys     |                                                                                    `{}` |
 
 # Options with context
 
@@ -258,6 +260,9 @@ Currently only 1 option is available:
 
 For SSR there is another context `SWRFallback` which as you can guess by the name let's you add fallback data for specific keys
 
+> [!NOTE]
+> As of 4.1.0 you can do the same with passing fallback to the Options context
+
 Example usage:
 
 ```tsx
@@ -283,6 +288,8 @@ function App() {
     return <></>;
 }
 ```
+
+This behavior can be scoped locally to a hook with the `fallback` option
 
 # useSWRInfinite
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "solid-swr",
     "description": "The beloved swr package ported over to solid",
-    "version": "4.0.9",
+    "version": "4.1.0",
     "type": "module",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/src/lib/context/fallback.ts
+++ b/src/lib/context/fallback.ts
@@ -1,5 +1,5 @@
 import { createContext } from "solid-js";
 
-type Fallback = Record<string, any>;
+import { Fallback } from "~/types";
 
 export const SWRFallback = createContext<Fallback>({});

--- a/src/lib/hooks/useOptions.ts
+++ b/src/lib/hooks/useOptions.ts
@@ -36,6 +36,8 @@ export default function useOptions<Res, Err>(
 
             revalidateOnFocus: true,
             revalidateOnOnline: true,
+
+            fallback: {},
         } satisfies Required<Options<Res, Err>>,
         context,
         options

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -58,7 +58,9 @@ export default function useSWR<Res = unknown, Err = unknown>(
     _options: Options<Res, Err> = {}
 ) {
     const options = useOptions<Res, Err>(_options);
-    const fallback = useContext(SWRFallback);
+    const fallbackContext = useContext(SWRFallback);
+
+    const getFallback = (key: string) => options.fallback[key] ?? fallbackContext[key];
 
     const peekCache = (k: string | undefined): CacheItem<Res> | undefined => {
         if (k === undefined) return undefined;
@@ -66,7 +68,7 @@ export default function useSWR<Res = unknown, Err = unknown>(
         const fromCache = options.cache.get(k);
         if (fromCache) return fromCache;
 
-        const fromFallback = fallback[k] as Res | undefined;
+        const fromFallback = getFallback(k) as Res | undefined;
         if (fromFallback) return { busy: false, data: fromFallback };
 
         return undefined;

--- a/src/lib/types/index.d.ts
+++ b/src/lib/types/index.d.ts
@@ -24,6 +24,8 @@ export type FetcherArg = {
 
 export type Fetcher<T> = (key: ExistentKey, arg: FetcherArg) => Promise<T>;
 
+export type Fallback = Record<string, any>;
+
 export type Options<Res, Err> = {
     /**
      * The function responsible for throwing errors and returning data
@@ -54,6 +56,11 @@ export type Options<Res, Err> = {
      * by default a simple in-memory LRU cache is used with 5K max items
      */
     cache?: CacheImplements<Res>;
+
+    /**
+     * A local SWRFallback option, pass initial data to a single hook
+     */
+    fallback?: Fallback;
 
     /**
      * Automatically revalidate when window has gotten focus

--- a/src/tests/options.test.ts
+++ b/src/tests/options.test.ts
@@ -196,3 +196,17 @@ it.each(["onError", "onSuccess"] as const)(
         expect(callback).toBeCalledWith({ a: { b: "foo" } });
     }
 );
+
+it("fallback passed locally works", () => {
+    const fetcher = vi.fn(async (k: string) => {
+        await waitForMs();
+        return k;
+    });
+
+    const { result } = renderHook(useSWR, [
+        () => "foo",
+        { fetcher, fallback: { foo: "foo" } },
+    ]);
+
+    expect(result.data.v).toBe("foo");
+});


### PR DESCRIPTION
Changes:
- adds `fallback` to swr options to specify fallback also per hook, as opposed to only with context

closes #59